### PR TITLE
suggested modifications before merging

### DIFF
--- a/tenpy/models/hofstadter.py
+++ b/tenpy/models/hofstadter.py
@@ -76,7 +76,7 @@ def gauge_hopping(gauge, mx, my, Jx, Jy, phi_pq):
     # it is 'tiled', i.e. repeated periodically, see also tenpy.tools.to_array().
     # If no magnetic unit cell size is defined, minimal size will be used.
     phi_p, phi_q = phi_pq
-    phi = 2 * np.pi * phi_p, phi_q
+    phi = 2 * np.pi * phi_p / phi_q
     if gauge == 'landau_x':
         # hopping in x-direction: uniform
         # hopping in y-direction: depends on x, shape (mx, 1)
@@ -299,13 +299,13 @@ class HofstadterBosons(CouplingModel, MPOModel):
         phi_pq = get_parameter(model_params, 'phi', (1, 4), self.name)
         phi_ext = get_parameter(model_params, 'phi_ext', 0., self.name)
         mu = get_parameter(model_params, 'mu', 1., self.name, True)
-        U = get_parameter(model_params, 'U', 0, self.name)
+        U = get_parameter(model_params, 'U', 0, self.name, True)
         gauge = get_parameter(model_params, 'gauge', 'landau_x', self.name)
         hop_x, hop_y = gauge_hopping(gauge, mx, my, Jx, Jy, phi_pq)
 
         # 6) add terms of the Hamiltonian
-        self.add_onsite(np.asarray(U) / 2, 0, 'NN')
-        self.add_onsite(-np.asarray(U) / 2 - np.asarray(mu), 0, 'N')
+        self.add_onsite(U / 2, 0, 'NN')
+        self.add_onsite(-U / 2 - mu, 0, 'N')
         dx = np.array([1, 0])
         self.add_coupling(hop_x, 0, 'Bd', 0, 'B', dx)
         self.add_coupling(np.conj(hop_x), 0, 'Bd', 0, 'B', -dx)  # h.c.

--- a/tenpy/models/hofstadter.py
+++ b/tenpy/models/hofstadter.py
@@ -18,7 +18,7 @@ from ..networks.site import BosonSite, FermionSite
 from .model import CouplingModel, MPOModel, CouplingMPOModel
 from ..tools.params import get_parameter, unused_parameters
 
-__all__ = ['HofstadterBosons', 'HofstadterFermions']
+__all__ = ['HofstadterBosons', 'HofstadterFermions', 'gauge_hopping']
 
 
 def gauge_hopping(gauge, mx, my, Jx, Jy, phi_pq):
@@ -92,7 +92,7 @@ def gauge_hopping(gauge, mx, my, Jx, Jy, phi_pq):
         if my is None:
             my = phi_q
         hop_y = -Jy
-        hop_x = -Jx * np.exp(1.j * phi * np.arange(my)[np.newaxis, :])  # has shape (1, Ly)
+        hop_x = -Jx * np.exp(-1.j * phi * np.arange(my)[np.newaxis, :])  # has shape (1, Ly)
     elif gauge == 'symmetric':
         # hopping in x-direction: depends on y, shape (mx, my)
         # hopping in y-direction: depends on x, shape (mx, my)
@@ -102,7 +102,7 @@ def gauge_hopping(gauge, mx, my, Jx, Jy, phi_pq):
             mx = my = np.sqrt(phi_q)
             assert np.issubdtype(mx, int)
             assert np.issubdtype(my, int)
-        hop_x = -Jx * np.exp(1.j * (phi/2) * np.arange(my)[:, np.newaxis])
+        hop_x = -Jx * np.exp(-1.j * (phi/2) * np.arange(my)[:, np.newaxis])
         hop_y = -Jy * np.exp(1.j * (phi/2) * np.arange(mx)[np.newaxis, :])
     else:
         raise ValueError("Undefinied gauge " + repr(gauge))
@@ -156,7 +156,7 @@ class HofstadterFermions(CouplingMPOModel):
         External magnetic flux 'threaded' through the cylinder.
     gauge : 'landau_x' | 'landau_y' | 'symmetric'
         Choice of the gauge used for the magnetic field. This changes the
-        magnetic unit cell.
+        magnetic unit cell. See :func:`gauge_hopping` for details.
     """
 
     def __init__(self, model_params):

--- a/tenpy/models/hofstadter.py
+++ b/tenpy/models/hofstadter.py
@@ -5,9 +5,7 @@
     Use at your own risk!
     Gauge-based hopping parametres currently assume Lx, Ly to be the size of the magnetic unit cell. MUC needs to be independently defined!
     Replicate known results to confirm models work correctly.
-    Implement different gauges (landau_y, symmetric/periodic, ...)
     Add assertions for consistency between gauge and lattice
-    Move hop_x, hop_y computation based on gauge to helper function outside classes?
     Long term: implement different lattices
 """
 # Copyright 2018 TeNPy Developers
@@ -23,85 +21,91 @@ from ..tools.params import get_parameter, unused_parameters
 __all__ = ['HofstadterBosons', 'HofstadterFermions']
 
 
-def gauge_hopping(gauge, mx, my, Jx, Jy, phi, phi_pq):
+def gauge_hopping(gauge, mx, my, Jx, Jy, phi_pq):
     r"""Compute hopping amplitudes for the Hofstadter models based on a gauge choice.
 
     In the Hofstadter model, the magnetic field enters as an Aharonov-Bohm phase.
     This phase is dependent on a choice of gauge, which simultaneously defines a
-    'magnetic unit cell' (MUC). 
+    'magnetic unit cell' (MUC).
 
-    The magnetic unit cell is the smallest set of lattice plaquettes that 
+    The magnetic unit cell is the smallest set of lattice plaquettes that
     encloses an integer number of flux quanta. It can be user-defined by setting
-    mx and my, but for common gauge choices is computed based on the flux 
+    mx and my, but for common gauge choices is computed based on the flux
     density.
 
     The gauge choices are:
         * 'landau_x': Landau gauge along the x-axis. The magnetic unit cell will
-          have shape :math`(\mathtt{mx}, 1)`. For flux densities :math:`p/q`, mx will default to q.
-          Example: at a flux density :math:`1/3`, the magnetic unit cell will have shape 
+          have shape :math`(\mathtt{mx}, 1)`. For flux densities :math:`p/q`, `mx` will default to q.
+          Example: at a flux density :math:`1/3`, the magnetic unit cell will have shape
           :math:`(3,1)`, so it encloses exactly 1 flux quantum.
         * 'landau_y': Landau gauge along the y-axis. The magnetic unit cell will
-          have shape :math`(1, \mathtt{my})`. For flux densities :math`p/q`, my will default to q.
+          have shape :math`(1, \mathtt{my})`. For flux densities :math`p/q`, `my` will default to q.
           Example: at a flux density :math:`3/7`, the magnetic unit cell will have shape
           :math:`(1,7)`, so it encloses axactly 3 flux quanta.
         * 'symmetric': symmetric gauge. The magnetic unit cell will have shape
-          :math:`(\mathtt{mx}, \mathtt{my})`, with :math:`mx = my`. For flux densities :math:`p/q`, 
-          mx and my will default to :math:`\sqrt{q}`
+          :math:`(\mathtt{mx}, \mathtt{my})`, with :math:`mx = my`. For flux densities :math:`p/q`,
+          `mx` and `my` will default to :math:`\sqrt{q}`
           Example: at a flux density 4/9, the magnetic unit cell will have shape
           (3,3), so it encloses exactly 4 flux quanta.
 
     .. todo :
         Add periodic gauge (generalization of symmetric with mx, my unequal)
-    
+
     Parameters
     ----------
     gauge : 'landau_x' | 'landau_y' | 'symmetric'
-        Choice of the gauge
-    mx, my : int
+        Choice of the gauge, see table above.
+    mx, my : int | None
         Dimensions of the magnetic unit cell in terms of lattice sites.
+        ``None`` defaults to the minimal choice compatible with `gauge` and `phi_pq`.
     Jx, Jy: float
-        `Bare' hopping amplitudes (without phase)
-    phi : float
-        Magnetic flux.
-    phi : tuple
+        'Bare' hopping amplitudes (without phase).
+        Without any flux we have ``hop_x = -Jx`` and ``hop_y = -Jy``.
+    phi_pq : tuple (int, int)
         Magnetic flux as a fraction p/q, defined as (p, q)
+
+    Returns
+    -------
+    hop_x, hop_y : float | array
+        Hopping amplitudes to be used as prefactors for :math:`c^\dagger_{x,y} c_{x+1,y}` (`hop_x`)
+        and :math:`c^\dagger_{x,y} c_{x,y+1}` (`hop_x`), respectively, with the necessary phases
+        for the gauge.
     """
+    # The hopping amplitudes depend on position -> use an array for couplings.
+    # If the array is smaller than the actual number of couplings,
+    # it is 'tiled', i.e. repeated periodically, see also tenpy.tools.to_array().
+    # If no magnetic unit cell size is defined, minimal size will be used.
+    phi_p, phi_q = phi_pq
+    phi = 2 * np.pi * phi_p, phi_q
     if gauge == 'landau_x':
         # hopping in x-direction: uniform
-        # hopping in y-direction:
-        # The hopping amplitudes depend on position -> use an array for couplings.
-        # If the array is smaller than the actual number of couplings,
-        # it is 'tiled', i.e. repeated periodically, see also tenpy.tools.to_array().
-        # (mx, 1) can be tiled to (Lx,Ly-1) for 'ladder' and (Lx, Ly) for 'cylinder' bc.
-        # If no magnetic unit cell size is defined, minimal size will be used.
-        if mx == 0: mx = phi_pq[1]
+        # hopping in y-direction: depends on x, shape (mx, 1)
+        # can be tiled to (Lx,Ly-1) for 'ladder' and (Lx, Ly) for 'cylinder' bc.
+        if mx is None:
+            mx = phi_q
         hop_x = -Jx
         hop_y = -Jy * np.exp(1.j * phi * np.arange(mx)[:, np.newaxis])  # has shape (Lx, 1)
     elif gauge == 'landau_y':
+        # hopping in x-direction: depends on y, shape (1, my)
         # hopping in y-direction: uniform
-        # hopping in x-direction:
-        # The hopping amplitudes depend on position -> use an array for couplings.
-        # If the array is smaller than the actual number of couplings,
-        # it is 'tiled', i.e. repeated periodically, see also tenpy.tools.to_array().
-        # (1, my) can be tiled to (Lx,Ly-1) for 'ladder' and (Lx, Ly) for 'cylinder' bc.
-        # If no magnetic unit cell size is defined, minimal size will be used.
-        if my == 0: my = phi_pq[1]
+        # can be tiled to (Lx,Ly-1) for 'ladder' and (Lx, Ly) for 'cylinder' bc.
+        if my is None:
+            my = phi_q
         hop_y = -Jy
         hop_x = -Jx * np.exp(1.j * phi * np.arange(my)[np.newaxis, :])  # has shape (1, Ly)
     elif gauge == 'symmetric':
-        # hopping in x-direction depends on y-coordinate. Hopping in y-direction depends on 
-        # x-coordinate.
-        # If no magnetic unit cell size is defined, minimal size will be used.
-        if mx == 0 or my == 0:
+        # hopping in x-direction: depends on y, shape (mx, my)
+        # hopping in y-direction: depends on x, shape (mx, my)
+        if mx is None or my is None:
             # TODO Rework so minimal MUC always contains integer number of flux quanta (i.e. not sqrt).
             warnings.warn("Magnetic unit cell not (fully) specified.")
-            mx = my = np.sqrt(phi_pq[1])
+            mx = my = np.sqrt(phi_q)
             assert np.issubdtype(mx, int)
             assert np.issubdtype(my, int)
         hop_x = -Jx * np.exp(1.j * (phi/2) * np.arange(my)[:, np.newaxis])
         hop_y = -Jy * np.exp(1.j * (phi/2) * np.arange(mx)[np.newaxis, :])
     else:
-        raise NotImplementedError()
+        raise ValueError("Undefinied gauge " + repr(gauge))
     return hop_x, hop_y
 
 
@@ -116,7 +120,7 @@ class HofstadterFermions(CouplingMPOModel):
             - \sum_{x, y} \mathtt{mu} n_{x,y},
 
     where :math:`e^{i \mathtt{phi}_{x,y} }` is a complex Aharonov-Bohm hopping
-    phase, depending on lattice coordinates and gauge choice (see 
+    phase, depending on lattice coordinates and gauge choice (see
     :func:`tenpy.models.hofstadter.gauge_hopping`).
 
     All parameters are collected in a single dictionary `model_params` and read out with
@@ -151,7 +155,7 @@ class HofstadterFermions(CouplingMPOModel):
     phi_ext : float
         External magnetic flux 'threaded' through the cylinder.
     gauge : 'landau_x' | 'landau_y' | 'symmetric'
-        Choice of the gauge used for the magnetic field. This changes the 
+        Choice of the gauge used for the magnetic field. This changes the
         magnetic unit cell.
     """
 
@@ -184,21 +188,22 @@ class HofstadterFermions(CouplingMPOModel):
     def init_terms(self, model_params):
         Lx = self.lat.shape[0]
         Ly = self.lat.shape[1]
-        mx = get_parameter(model_params, 'mx', 0, self.name)
-        my = get_parameter(model_params, 'my', 0, self.name)
+        mx = get_parameter(model_params, 'mx', None, self.name)
+        my = get_parameter(model_params, 'my', None, self.name)
         Jx = get_parameter(model_params, 'Jx', 1., self.name)
         Jy = get_parameter(model_params, 'Jy', 1., self.name)
         phi_pq = get_parameter(model_params, 'phi', (1, 3), self.name)
-        phi = 2 * np.pi * phi_pq[0] / phi_pq[1]
         phi_ext = get_parameter(model_params, 'phi_ext', 0., self.name)
         mu = get_parameter(model_params, 'mu', 1., self.name, True)
         gauge = get_parameter(model_params, 'gauge', 'landau_x', self.name)
-        hop_x, hop_y = gauge_hopping(gauge, mx, my, Jx, Jy, phi, phi_pq)
+        hop_x, hop_y = gauge_hopping(gauge, mx, my, Jx, Jy, phi_pq)
 
         # 6) add terms of the Hamiltonian
         self.add_onsite(-mu, 0, 'N')
-        self.add_coupling(hop_x, 0, 'Cd', 0, 'C', (1, 0))
-        self.add_coupling(np.conj(hop_x), 0, 'Cd', 0, 'C', (-1, 0))  # h.c.
+        dx = np.array([1, 0])
+        # hop_x = self.coupling_strength_add_ext_flux(hop_x, dx, [0, phi_ext]) # does nothing...
+        self.add_coupling(hop_x, 0, 'Cd', 0, 'C', dx)
+        self.add_coupling(np.conj(hop_x), 0, 'Cd', 0, 'C', -dx)  # h.c.
         dy = np.array([0, 1])
         hop_y = self.coupling_strength_add_ext_flux(hop_y, dy, [0, phi_ext])
         self.add_coupling(hop_y, 0, 'Cd', 0, 'C', dy)
@@ -216,7 +221,7 @@ class HofstadterBosons(CouplingModel, MPOModel):
             + \sum_{x, y} \frac{\mathtt{U}}{2} n_{x,y} (n_{x,y} - 1) - \mathtt{mu} n_{x,y}
 
     where :math:`e^{i \mathtt{phi}_{x,y} }` is a complex Aharonov-Bohm hopping
-    phase, depending on lattice coordinates and gauge choice (see 
+    phase, depending on lattice coordinates and gauge choice (see
     :func:`tenpy.models.hofstadter.gauge_hopping`).
 
     All parameters are collected in a single dictionary `model_params` and read out with
@@ -253,8 +258,8 @@ class HofstadterBosons(CouplingModel, MPOModel):
     phi_ext : float
         External magnetic flux 'threaded' through the cylinder.
     gauge : 'landau_x' | 'landau_y' | 'symmetric'
-        Choice of the gauge used for the magnetic field. This changes the 
-        magnetic unit cell. 
+        Choice of the gauge used for the magnetic field. This changes the
+        magnetic unit cell.
     """
 
     def __init__(self, model_params):
@@ -287,23 +292,23 @@ class HofstadterBosons(CouplingModel, MPOModel):
     def init_terms(self, model_params):
         Lx = self.lat.shape[0]
         Ly = self.lat.shape[1]
-        mx = get_parameter(model_params, 'mx', 0, self.name)
-        my = get_parameter(model_params, 'my', 0, self.name)
+        mx = get_parameter(model_params, 'mx', None, self.name)
+        my = get_parameter(model_params, 'my', None, self.name)
         Jx = get_parameter(model_params, 'Jx', 1., self.name)
         Jy = get_parameter(model_params, 'Jy', 1., self.name)
         phi_pq = get_parameter(model_params, 'phi', (1, 4), self.name)
-        phi = 2 * np.pi * phi_pq[0] / phi_pq[1]
         phi_ext = get_parameter(model_params, 'phi_ext', 0., self.name)
         mu = get_parameter(model_params, 'mu', 1., self.name, True)
         U = get_parameter(model_params, 'U', 0, self.name)
         gauge = get_parameter(model_params, 'gauge', 'landau_x', self.name)
-        hop_x, hop_y = gauge_hopping(gauge, mx, my, Jx, Jy, phi, phi_pq)
+        hop_x, hop_y = gauge_hopping(gauge, mx, my, Jx, Jy, phi_pq)
 
         # 6) add terms of the Hamiltonian
         self.add_onsite(np.asarray(U) / 2, 0, 'NN')
         self.add_onsite(-np.asarray(U) / 2 - np.asarray(mu), 0, 'N')
-        self.add_coupling(hop_x, 0, 'Bd', 0, 'B', [1, 0])
-        self.add_coupling(np.conj(hop_x), 0, 'Bd', 0, 'B', [-1, 0])  # h.c.
+        dx = np.array([1, 0])
+        self.add_coupling(hop_x, 0, 'Bd', 0, 'B', dx)
+        self.add_coupling(np.conj(hop_x), 0, 'Bd', 0, 'B', -dx)  # h.c.
         dy = np.array([0, 1])
         hop_y = self.coupling_strength_add_ext_flux(hop_y, dy, [0, phi_ext])
         self.add_coupling(hop_y, 0, 'Bd', 0, 'B', dy)


### PR DESCRIPTION
thank's for creating the pull request, great work in separating the `gauge_hopping` function.

Looking at the changes, I think that the gauge in y-direction needs to get the modified sign of commit
81ac9623d6dab77312e6c60e8679f0c6378ddb3d. Do you agree?
As far as I see, the phases would otherwise exactly cancel to 0 for the symmetric gauge.

Another helpful thing might be to read out the parameters 'mx' and 'my' (and possibly others?) from the `model_params` only in the `gauge_hopping` function.
Currently, if `gauge` is 'landau_x', the 'mx' parameter is not used at all, which might lead to confusion.

Finally, (and not so urgent), I could also imagine to alter the hopping strength, say `Jx`, to have alternating weak and strong bonds. To allow for this case, it might be necessary to tile `Jx, Jy` and the  to the correct shape before multiplying them. Something along the lines of
```python
(_, c_shape) = self.lat._coupling_shape(dx)
Jx= to_array(Jx, c_shape)
```
(It would be good to make `_coupling_shape` public beforehand...)